### PR TITLE
Cosmetic changes

### DIFF
--- a/schema-test.json
+++ b/schema-test.json
@@ -99,7 +99,7 @@
             "description": "ISO 8601 timestamp of when the activity was started",
             "type": "string",
             "examples": [
-              "202104220800Z"
+              "2021-04-22T08:00Z"
             ]
           },
           "activity_ended": {
@@ -107,7 +107,7 @@
             "description": "ISO 8601 timestamp of when the activity ended",
             "type": "string",
             "examples": [
-              "202104220800Z"
+              "2021-04-22T08:00Z"
             ]
           },
           "source_os": {
@@ -120,7 +120,7 @@
           },
           "target_os": {
             "$id": "#root/activities/items/target_os",
-            "description": "Target operating system where the migration ended",
+            "description": "Target operating system of the migration activity",
             "type": "string",
             "examples": [
               "Red Hat Enterprise Linux 8.3"


### PR DESCRIPTION
'202104220800Z' is *NOT* a valid ISO8601 value, at least not from my knowledge
at least there needs to be the T inside, but the better human readable and compatible form is:
'2021-04-220T08:00Z'

The target OS version also is rather to be expected, than actually received. We can do generate the string - depending on the stage.
Since target_os is required always, according to the schema, the documentation expresses it now in a way that doesn't require this field only to be set once the migration completed. We could leave it empty, but I think that'd be irrelevant.
The intention of this field seems to rather express from where to where the upgrade should have been.
