### PR TITLE
repomap-schema: Add 'google' to the 'rhui' enum

### DIFF
--- a/repomap-schema-test.json
+++ b/repomap-schema-test.json
@@ -255,7 +255,8 @@
                 "rhui": {
                     "enum": [
                         "aws",
-                        "azure"
+                        "azure",
+                        "google"
                     ]
                 }
             }


### PR DESCRIPTION
This is needed to be able to cover repomap for GCP.

Related PR:
* https://github.com/oamg/leapp-repository/pull/897