### PR TITLE
Drop legal notice from PES events schema

### DIFF
--- a/pes-events-schema-test.json
+++ b/pes-events-schema-test.json
@@ -4,17 +4,11 @@
   "title": "Package Evolution Service - Events",
   "type": "object",
   "required": [
-    "legal_notice",
     "timestamp",
     "packageinfo",
     "provided_data_streams"
   ],
   "properties": {
-    "legal_notice": {
-      "type": "string",
-      "title": "Just a legal notice...",
-      "examples": ["Copyright YYYY ...."]
-    },
     "timestamp": {
         "type": "string",
         "title": "The datetime of the last data update.",


### PR DESCRIPTION
The legal notice is not present anymore for some time and has no real value as the json file is data file and cannot by covered by a copyright.